### PR TITLE
[#26] Fix links to dev guide

### DIFF
--- a/community.md
+++ b/community.md
@@ -19,7 +19,7 @@ TEAMMATES welcome any developer (especially student) to be a contributor to the 
 
 Contributors:
 * Have "pull" access to the main repository and the ops repository, and submit their fixes via pull requests (PRs) from their own forked repository.
-  The detailed workflow is given in [this document](https://github.com/TEAMMATES/teammates/blob/master/docs/process.md).
+  The detailed workflow is given in [this document](https://teammates.github.io/teammates/process.html).
 * Can open issues.
 * Can close issues and PRs opened by themselves.
 * Can comment on any issue and PR.

--- a/github-bot/README.md
+++ b/github-bot/README.md
@@ -13,7 +13,7 @@ This bot is deployed on Heroku.
 
 Deployment config:
 - `GITHUB_API_TOKEN` : The bot's GitHub API access token; known only to maintainers
-- `CONTRIBUTING_GUIDELINES`: [TEAMMATES contributing guidelines](https://github.com/TEAMMATES/teammates/blob/master/docs/CONTRIBUTING.md)
+- `CONTRIBUTING_GUIDELINES`: [TEAMMATES contributing guidelines](https://teammates.github.io/teammates/contributing-doc.html)
 - `REGEX_PULL_REQ_TITLE`: Regex to validate the PR title
 - `REGEX_PULL_REQ_BODY`: Regex to validate the PR description
 

--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -2,7 +2,7 @@
 
 This document details the tasks that need to be done by core team (afterwards "team") members (project maintainers) in order to keep the project moving.
 
-It is assumed that the team members are familiar with the [development workflow](https://github.com/TEAMMATES/teammates/blob/master/docs/process.md), [individual development process](https://github.com/TEAMMATES/teammates/blob/master/docs/development.md), and the terms used in the project as listed in those documents, [project glossary](https://github.com/TEAMMATES/teammates/blob/master/docs/glossary.md), [issue labels](https://github.com/TEAMMATES/teammates/blob/master/docs/issues.md), and beyond.
+It is assumed that the team members are familiar with the [development workflow](https://teammates.github.io/teammates/process.html), [individual development process](https://teammates.github.io/teammates/development.html), and the terms used in the project as listed in those documents, [project glossary](https://teammates.github.io/teammates/glossary.html), [issue labels](https://teammates.github.io/teammates/issues.html), and beyond.
 
 * Issue tracker management
   * [Triaging an issue](#triaging-an-issue)

--- a/platform-guide.md
+++ b/platform-guide.md
@@ -44,7 +44,7 @@ Note: This document does not have preference over either GAE standard or flexibl
      Modify if necessary, e.g. to change the version number displayed to user. Note that this modification needs to be done before building the front-end files.
 
 1. Ensure that the front-end files have been built.
-   * You can refer to the TEAMMATES [developer documentation](https://github.com/TEAMMATES/teammates/blob/master/docs/development.md#building-front-end-files) on building front-end files.
+   * You can refer to the TEAMMATES [developer documentation](https://teammates.github.io/teammates/development.html#building-front-end-files) on building front-end files.
 
 1. (Optional but recommended) If you are deploying the application only for testing purpose, it is highly recommended to not deploy the cron jobs as they will necessitate the application to have 100% uptime (thereby unnecessarily charging instance cost). You can achieve this in two different ways:
    * Use a deployment command that does not deploy the cron job. Details can be found in the next section.


### PR DESCRIPTION
Fixes the first point of #26 for the issue also described in TEAMMATES [#11736](https://github.com/TEAMMATES/teammates/issues/11736)

**Outline of Solution**
Changes links to point to the MarkBind dev guide. Does not update the teammates bot config (I think that's not something I can do?)

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
