### PR TITLE
Add note on Liquibase

### DIFF
--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -156,6 +156,7 @@ The complete details can be filled in just before merging and/or after the fix i
 Schema migration is necessary when tables/ columns are amended/ added. Refer to TEAMMATES repo [docs/schema-migration.md](https://github.com/TEAMMATES/teammates/tree/master/docs/schema-migration.md)
 
 **Role: RL**
+Note on release number: Since Liquibase runs changelogs in alphanumeric order e.g `db.changelog-v9.0.0.beta.2.xml` will run after `db.changelog-v9.0.0.beta.11.xml`
 * Follow dev guide to create new changelog with name `db.changelog-<release_number>.xml`. The previous release is the base and the new release is the target branch.
 * Manually add a new changeset to the bottom of changelog file, to tag the database (Refer to [official liquibase documentation](https://docs.liquibase.com/change-types/tag-database.html)).
 * Ensure new changelog is in `src/main/resources/db/changelog` and add it as the last entry in `src/main/resources/db/changelog/db.changelog-root.xml` (note changelogs are executed alphanumerically - careful if adding suffixes)


### PR DESCRIPTION
**Context**
Liquibase runs undeployed changelogs in alphanumeric order. If multiple changelogs have not been run this may be problematic for changelogs that are too large i.e Currently the beta release numbers may be large

**Outline of Solution**
A note on this was added for release leaders, in the event that the minor version go too high and a changelog has to be deployed
