### PR TITLE
Update schema migration docs

### DIFF
--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -159,10 +159,10 @@ The complete details can be filled in just before merging and/or after the fix i
 Schema migration is necessary when tables/ columns are amended/ added. Refer to TEAMMATES repo [docs/schema-migration.md](https://github.com/TEAMMATES/teammates/tree/master/docs/schema-migration.md)
 
 **Role: RL**
-Note on release number: Since Liquibase runs changelogs in alphanumeric order e.g `db.changelog-v9.0.0.beta.2.xml` will run after `db.changelog-v9.0.0.beta.11.xml`
+Note on release number: Since Liquibase runs changelogs in the order included in the `db.changelog-root.xml` irrespective of lexicographical order, so include the newest changelog at the bottom of the file 
 * Follow dev guide to create new changelog with name `db.changelog-<release_number>.xml`. The previous release is the base and the new release is the target branch.
 * Manually add a new changeset to the bottom of changelog file, to tag the database (Refer to [official liquibase documentation](https://docs.liquibase.com/change-types/tag-database.html)).
-* Ensure new changelog is in `src/main/resources/db/changelog` and add it as the last entry in `src/main/resources/db/changelog/db.changelog-root.xml` (note changelogs are executed alphanumerically - careful if adding suffixes)
+* Ensure new changelog is in `src/main/resources/db/changelog` and add it as the last entry in `src/main/resources/db/changelog/db.changelog-root.xml`
 * Notify PM of schema change for them to run on production database.
 
 **Role: PM**


### PR DESCRIPTION
Related to issue https://github.com/TEAMMATES/teammates/pull/13062

**Context**
Changelogs are run in numeric order if the [includeAll tag](https://docs.liquibase.com/change-types/includeall.html) is used to run changelogs. In Teammates, we use the [include tag](https://docs.liquibase.com/change-types/include.htm) which runs in the order they are placed in the changelog-root.xml file

**Outline of Solution**
Remove documentation which states that changelog naming affects changelog run order